### PR TITLE
fix: Modify APPTAINER_CACHE path in production config

### DIFF
--- a/config/config_production_pipeline.miarka.yaml
+++ b/config/config_production_pipeline.miarka.yaml
@@ -1,8 +1,7 @@
-PIPELINE_VERSION: v0.11.0
 
 REFERENCE_DATA: /proj/ngi2024001/nobackup/bin/wp3_hg/design_and_ref_files
 
-APPTAINER_CACHE: /proj/ngi2024001/nobackup/bin/wp3_hg/{{PIPELINE_VERSION}}/apptainer_cache
+APPTAINER_CACHE: /proj/ngi2024001/nobackup/bin/wp3_hg/apptainer_cache
 
 hydra_local_path: /proj/ngi2024001/nobackup/bin/wp3_hg/{{PIPELINE_VERSION}}/hydra-genetics
 


### PR DESCRIPTION
Updated APPTAINER_CACHE path to remove versioning.

Don't hardcode the version in the config. It can be specified in the snakemake command under --config PIPELINE_VERSION=$version